### PR TITLE
Add instructions for loading CC modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ Logic for ABC is in the file - mahimahi/src/packet/cellular_packet_queue.cc
 
 -----
 
+# Installing Congestion Control Modules
+
+Run `$ /sbin/sysctl net.ipv4.tcp_available_congestion_control` to see which modules are loaded in your kernel, and `$ /sbin/sysctl net.ipv4.tcp_allowed_congestion_control` to see which can be run without root permissions. We need `cubic`, `vegas`, and `bbr`.
+
+Run `$ ls -la /lib/modules/$(uname -r)/kernel/net/ipv4` to see the available modules.
+
+Run `modprobe` to load the modules that you need. For example:
+```
+$ sudo modprobe -a tcp_vegas
+$ sudo modprobe -a tcp_bbr
+```
+
+Running `$ /sbin/sysctl net.ipv4.tcp_available_congestion_control` again should now contain these modules.
+Some may still be missing from `$ /sbin/sysctl net.ipv4.tcp_allowed_congestion_control`. In this case, you will need to append to that file. When writing to the file you want to make sure that you don't remove existing protocols. For example:
+```
+echo cubic reno bbr vegas | sudo tee /proc/sys/net/ipv4/tcp_allowed_congestion_control
+```
+
 # Reproduction
 
 ## Figure 2

--- a/figure2.py
+++ b/figure2.py
@@ -53,7 +53,7 @@ BBR = CUBIC._replace(
     commands='./start-tcp.sh bbr'
 )
 
-PROTOS = [ABC, CUBIC, CUBIC_CODEL, CUBIC_PIE]
+PROTOS = [BBR, VEGAS, ABC, CUBIC, CUBIC_CODEL, CUBIC_PIE]
 stats = dict()
 
 def run_exp(proto, skip=False):

--- a/figure2a_plot.py
+++ b/figure2a_plot.py
@@ -9,14 +9,18 @@ COLORS = {
     'abc': 'blue',
     'cubicpie': 'black',
     'cubiccodel': 'green',
-    'cubic': 'brown'
+    'cubic': 'brown',
+    'bbr': 'red',
+    'vegas': 'cyan'
 }
 
 NAMES = {
     'abc': 'ABC',
     'cubicpie': 'Cubic+Pie',
     'cubiccodel': 'Cubic+Codel',
-    'cubic': 'Cubic'
+    'cubic': 'Cubic',
+    'bbr': 'BBR',
+    'vegas': 'Vegas'
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds commands to the readme to load kernel congestion control modules (I
was getting `not found` for BBR and Vegas). Adds BBR and Vegas back to
scripts now that we know how to load them.