### PR TITLE
Ability to use downlink log for verus

### DIFF
--- a/protocols/cc_protocol.py
+++ b/protocols/cc_protocol.py
@@ -12,7 +12,7 @@ import collections
 class CCProtocol:
 
     fig_2_base_cmd_fmt = "mm-delay {delay} \
-            mm-link --once --uplink-log={uplink_log} \
+            mm-link --once --{link}-log={log} \
             {queue_args} \
             {uplink} {downlink} \
             -- bash -c '{mahimahi_command}'"
@@ -20,8 +20,8 @@ class CCProtocol:
     fig_2_results_cmd_fmt = "mm-throughput-graph 500 {log_file} > \
             {graph_file} 2> {results_file}"
 
-    mahimahi_queue_args_fmt = "--uplink-queue={uplink_queue} \
-            --uplink-queue-args=\"{uplink_queue_args}\""
+    mahimahi_queue_args_fmt = "--{link}-queue={queue} \
+            --{link}-queue-args=\"{queue_args}\""
 
     def __init__(self, config_file_path, results_file_path, 
             uplink_log_file_path, extra_args):
@@ -53,20 +53,23 @@ class CCProtocol:
         """ Returns ordered dictionary of commands
         to run to generate Figure 2 results.
         """
-        
+        link = self.config.get('link', 'uplink')
         if self.config['uplink_queue'] == '':
             queue_args = ''
         else:
             queue_args = self.mahimahi_queue_args_fmt.format(
-                    uplink_queue=self.config['uplink_queue'], 
-                    uplink_queue_args=self.config['uplink_queue_args']
+                    link=link,
+                    queue=self.config['uplink_queue'], 
+                    queue_args=self.config['uplink_queue_args']
             )
 
         prep_commands = self.config['prep_commands']
+        uplink = uplink_trace if link == 'uplink' else downlink_trace
+        downlink = downlink_trace if link == 'uplink' else uplink_trace
         mahimahi_cmd = self.fig_2_base_cmd_fmt.format(
-                delay=str(mm_delay), uplink_log=self.uplink_log_file_path,
-                queue_args=queue_args, uplink=uplink_trace,
-                downlink=downlink_trace, mahimahi_command=self.config['mahimahi_command']
+                link=link, delay=str(mm_delay), log=self.uplink_log_file_path,
+                queue_args=queue_args, uplink=uplink,
+                downlink=downlink, mahimahi_command=self.config['mahimahi_command']
         )
         
         graph_out = '/dev/null'

--- a/protocols/cc_protocol.py
+++ b/protocols/cc_protocol.py
@@ -8,7 +8,6 @@ import json
 import pprint
 import collections
 
-
 class CCProtocol:
 
     fig_2_base_cmd_fmt = "mm-delay {delay} \
@@ -53,23 +52,24 @@ class CCProtocol:
         """ Returns ordered dictionary of commands
         to run to generate Figure 2 results.
         """
+        FLIP_FULL = True
         link = self.config.get('link', 'uplink')
         if self.config['uplink_queue'] == '':
             queue_args = ''
         else:
             queue_args = self.mahimahi_queue_args_fmt.format(
-                    link=link,
+                    link=link if FLIP_FULL else 'uplink',
                     queue=self.config['uplink_queue'], 
                     queue_args=self.config['uplink_queue_args']
             )
 
         prep_commands = self.config['prep_commands']
-        uplink = uplink_trace if link == 'uplink' else downlink_trace
-        downlink = downlink_trace if link == 'uplink' else uplink_trace
+        if link == 'downlink' and FLIP_FULL:
+            uplink_trace, downlink_trace = (downlink_trace, uplink_trace)
         mahimahi_cmd = self.fig_2_base_cmd_fmt.format(
                 link=link, delay=str(mm_delay), log=self.uplink_log_file_path,
-                queue_args=queue_args, uplink=uplink,
-                downlink=downlink, mahimahi_command=self.config['mahimahi_command']
+                queue_args=queue_args, uplink=uplink_trace,
+                downlink=downlink_trace, mahimahi_command=self.config['mahimahi_command']
         )
         
         graph_out = '/dev/null'

--- a/protocols/cc_protocol.py
+++ b/protocols/cc_protocol.py
@@ -11,7 +11,7 @@ import collections
 class CCProtocol:
 
     fig_2_base_cmd_fmt = "mm-delay {delay} \
-            mm-link --once --{link}-log={log} \
+            mm-link --once --{target_link}-log={log} \
             {queue_args} \
             {uplink} {downlink} \
             -- bash -c '{mahimahi_command}'"
@@ -19,8 +19,8 @@ class CCProtocol:
     fig_2_results_cmd_fmt = "mm-throughput-graph 500 {log_file} > \
             {graph_file} 2> {results_file}"
 
-    mahimahi_queue_args_fmt = "--{link}-queue={queue} \
-            --{link}-queue-args=\"{queue_args}\""
+    mahimahi_queue_args_fmt = "--{target_link}-queue={queue} \
+            --{target_link}-queue-args=\"{queue_args}\""
 
     def __init__(self, config_file_path, results_file_path, 
             uplink_log_file_path, extra_args):
@@ -53,21 +53,21 @@ class CCProtocol:
         to run to generate Figure 2 results.
         """
         FLIP_FULL = True
-        link = self.config.get('link', 'uplink')
+        target_link = self.config.get('target_link', 'uplink')
         if self.config['uplink_queue'] == '':
             queue_args = ''
         else:
             queue_args = self.mahimahi_queue_args_fmt.format(
-                    link=link if FLIP_FULL else 'uplink',
+                    target_link=target_link if FLIP_FULL else 'uplink',
                     queue=self.config['uplink_queue'], 
                     queue_args=self.config['uplink_queue_args']
             )
 
         prep_commands = self.config['prep_commands']
-        if link == 'downlink' and FLIP_FULL:
+        if target_link == 'downlink' and FLIP_FULL:
             uplink_trace, downlink_trace = (downlink_trace, uplink_trace)
         mahimahi_cmd = self.fig_2_base_cmd_fmt.format(
-                link=link, delay=str(mm_delay), log=self.uplink_log_file_path,
+                target_link=target_link, delay=str(mm_delay), log=self.uplink_log_file_path,
                 queue_args=queue_args, uplink=uplink_trace,
                 downlink=downlink_trace, mahimahi_command=self.config['mahimahi_command']
         )

--- a/protocols/config/verus.json
+++ b/protocols/config/verus.json
@@ -6,5 +6,5 @@
                        "killall verus_server", "killall verus_client"],
   "uplink_queue": "droptail",
   "uplink_queue_args": "packets=100",
-  "link": "downlink"
+  "target_link": "downlink"
 }

--- a/protocols/config/verus.json
+++ b/protocols/config/verus.json
@@ -5,5 +5,6 @@
   "cleanup_commands": ["killall sender", "killall receiver", 
                        "killall verus_server", "killall verus_client"],
   "uplink_queue": "droptail",
-  "uplink_queue_args": "packets=100"
+  "uplink_queue_args": "packets=100",
+  "link": "downlink"
 }


### PR DESCRIPTION
I know that `FULL_FLIP` is pretty hacky, but while I'm _pretty sure_ we're supposed to flip all of the queues, etc. I am currently getting a super long delay for verus when everything is flipped, so the results are more accurate with just switching the log file, and I want a way to be able to switch between the two quickly. This would be removed before the end of the project.