### PR TITLE
Remove full flip

### DIFF
--- a/protocols/cc_protocol.py
+++ b/protocols/cc_protocol.py
@@ -52,19 +52,18 @@ class CCProtocol:
         """ Returns ordered dictionary of commands
         to run to generate Figure 2 results.
         """
-        FLIP_FULL = True
         target_link = self.config.get('target_link', 'uplink')
         if self.config['uplink_queue'] == '':
             queue_args = ''
         else:
             queue_args = self.mahimahi_queue_args_fmt.format(
-                    target_link=target_link if FLIP_FULL else 'uplink',
+                    target_link=target_link,
                     queue=self.config['uplink_queue'], 
                     queue_args=self.config['uplink_queue_args']
             )
 
         prep_commands = self.config['prep_commands']
-        if target_link == 'downlink' and FLIP_FULL:
+        if target_link == 'downlink':
             uplink_trace, downlink_trace = (downlink_trace, uplink_trace)
         mahimahi_cmd = self.fig_2_base_cmd_fmt.format(
                 target_link=target_link, delay=str(mm_delay), log=self.uplink_log_file_path,


### PR DESCRIPTION
This is no longer needed, since full flip is correct and delay is on par with other droptail cues after I applied the patch. 

Also, somewhat unrelated, I modified some of the queue args (set target=60) for cubic+codel and got it's overall dot closer to the original result, but the throughput was further from their results so i'm not sure if we should arbitrarily change that parameter. Interestingly, according to [this](https://www.systutorials.com/docs/linux/man/8-tc-codel/#lbAH) target should be 5, and when I used target=20 I got a power score of 30, which is a teeny bit higher than ABC's power score.