### PR TITLE
Update fig2 plot to use correct delay and add run_experiments.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ To load modules, run `modprobe`. (eg: `sudo modprobe -a tcp_vegas`). You should 
 
 # Reproduction
 
+To generate the graphs in our report, run:
+```
+$ sh run_experiments.sh
+```
+When this completes, the plots will be saved as `figure2a_plot.svg` and `figure2b_plot.svg`
+
 ## Figure 2
 
 `experiments.py` contains the code to reproduce Figure 2 (as well as other figures). This runs traces against each protocol and optionally saves the utilization and delay results to a csv file. The `--schemes` command-line parameter takes in a comma-separated list of protocols to run.  If the option is not given, results for all protocols are generated. The `--experiment` parameter takes a string in `figure2a, figure2b, bothlinks` according to which experiment we are running.
@@ -52,10 +58,12 @@ Lastly, the command-line parameter `--csv-out` allows you to specify a filename 
 
 ### Generating Figure Plots
 
-`figure2_plot.py` takes a csv results file from `experiments.py` and creates a matplotlib graph with the same format as the figure from the original paper.
+`figure2_plot.py [data-filename] [plot-filename]` takes a csv results file from `experiments.py` and creates a matplotlib graph with the same format as the figure from the original paper.
+
+`--original-figure` is an optional argument that plots the provided data in comparison to the results from the original ABC paper.
 
 Example:
 ```
-$ python figure2.py --experiment figure2a --reuse-results all --csv-out results
-$ python figure2_plot.py --data-filename results.csv --plot-filename plot
+$ python experiment.py --schemes all --experiment figure2a --csv-out results.csv
+$ python figure2_plot.py results.csv plot.svg -o 2a
 ```

--- a/run_experiments.sh
+++ b/run_experiments.sh
@@ -1,0 +1,4 @@
+python experiment.py --schemes sprout cubiccodel cubicpie abc vegas verus bbr cubic --experiment figure2a --csv-out figure2a_results.csv
+python figure2_plot.py figure2a_results.csv figure2a_plot.svg -o 2a
+python experiment.py --schemes sprout cubiccodel cubicpie abc vegas verus bbr cubic --experiment figure2b --csv-out figure2b_results.csv
+python figure2_plot.py figure2b_results.csv figure2b_plot.svg -o 2b


### PR DESCRIPTION
`figure2_plot.py` now uses queueing delay + RTT (hardcoded as 100) for the x-axis delay.

`run_experiments.sh` runs the exact commands to generate the graphs for our final report (will obviously be updated before we submit, this is just for our current 'final' graphs)

Also updates readme

Removes unnecessary things from `figure2_plot.py`